### PR TITLE
fix: handle deleting chat and supervisor

### DIFF
--- a/src/components/chat-sidebar/chat-sidebar-link.tsx
+++ b/src/components/chat-sidebar/chat-sidebar-link.tsx
@@ -1,5 +1,8 @@
+"use client";
+
 import { Trash2 } from "lucide-react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 
 import { Button } from "@/components/ui/button";
 import { SidebarMenuButton, SidebarMenuItem } from "@/components/ui/sidebar";
@@ -8,11 +11,14 @@ export function ChatSidebarLink({
   uuid,
   title,
   removeChat,
+  toRedirect,
 }: Readonly<{
   uuid: string;
   title: string;
   removeChat: (_uuid: string) => void;
+  toRedirect: boolean;
 }>) {
+  const router = useRouter();
   return (
     <SidebarMenuItem>
       <SidebarMenuButton asChild>
@@ -31,6 +37,10 @@ export function ChatSidebarLink({
               event.preventDefault();
               event.stopPropagation();
               removeChat(uuid);
+              if (toRedirect) {
+                console.log("INSIDE REDIRECTING");
+                router.replace("/chat");
+              }
             }}
           >
             <Trash2 size={16} />

--- a/src/components/chat-sidebar/chat-sidebar-link.tsx
+++ b/src/components/chat-sidebar/chat-sidebar-link.tsx
@@ -2,7 +2,6 @@
 
 import { Trash2 } from "lucide-react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
 
 import { Button } from "@/components/ui/button";
 import { SidebarMenuButton, SidebarMenuItem } from "@/components/ui/sidebar";
@@ -11,14 +10,11 @@ export function ChatSidebarLink({
   uuid,
   title,
   removeChat,
-  toRedirect,
 }: Readonly<{
   uuid: string;
   title: string;
   removeChat: (_uuid: string) => void;
-  toRedirect: boolean;
 }>) {
-  const router = useRouter();
   return (
     <SidebarMenuItem>
       <SidebarMenuButton asChild>
@@ -27,7 +23,6 @@ export function ChatSidebarLink({
           className="flex flex-row items-center justify-between"
         >
           <span className="truncate">{title}</span>
-
           <Button
             size="icon"
             className="flex-none transition hover:text-red-500"
@@ -37,10 +32,6 @@ export function ChatSidebarLink({
               event.preventDefault();
               event.stopPropagation();
               removeChat(uuid);
-              if (toRedirect) {
-                console.log("INSIDE REDIRECTING");
-                router.replace("/chat");
-              }
             }}
           >
             <Trash2 size={16} />

--- a/src/components/chat-sidebar/chat-sidebar.tsx
+++ b/src/components/chat-sidebar/chat-sidebar.tsx
@@ -2,6 +2,7 @@
 
 import { NotebookPen, Star } from "lucide-react";
 import Link from "next/link";
+import { useParams, usePathname } from "next/navigation";
 import { useState } from "react";
 
 import { ChatSidebarLink } from "@/components/chat-sidebar/chat-sidebar-link";
@@ -24,6 +25,13 @@ import { SupervisorSidebarLink } from "./supervisor-sidebar-link";
 export type Tab = "chats" | "supervisors";
 
 export function ChatSidebar() {
+  const pathname = usePathname();
+  const { uuid: currentUuid } = useParams<{ uuid: string | undefined }>();
+  const { chatUuid, supervisorUuid } = pathname.includes("chat")
+    ? { chatUuid: currentUuid, supervisorUuid: undefined }
+    : { chatUuid: undefined, supervisorUuid: currentUuid };
+  console.log(`CHAT UUID = ${chatUuid ?? ""}`);
+  console.log(`SUPERVISOR UUID = ${supervisorUuid ?? ""}`);
   const { chats, removeChat } = useChats();
   const { supervisors, removeSupervisor } = useSupervisors();
   const [tab, setTab] = useState<Tab>("chats");
@@ -36,6 +44,7 @@ export function ChatSidebar() {
             uuid={chat.uuid}
             title={chat.prompt}
             removeChat={removeChat}
+            toRedirect={currentUuid === chat.uuid}
           />
         ));
       }

--- a/src/components/chat-sidebar/chat-sidebar.tsx
+++ b/src/components/chat-sidebar/chat-sidebar.tsx
@@ -2,7 +2,6 @@
 
 import { NotebookPen, Star } from "lucide-react";
 import Link from "next/link";
-import { useParams, usePathname } from "next/navigation";
 import { useState } from "react";
 
 import { ChatSidebarLink } from "@/components/chat-sidebar/chat-sidebar-link";
@@ -25,13 +24,6 @@ import { SupervisorSidebarLink } from "./supervisor-sidebar-link";
 export type Tab = "chats" | "supervisors";
 
 export function ChatSidebar() {
-  const pathname = usePathname();
-  const { uuid: currentUuid } = useParams<{ uuid: string | undefined }>();
-  const { chatUuid, supervisorUuid } = pathname.includes("chat")
-    ? { chatUuid: currentUuid, supervisorUuid: undefined }
-    : { chatUuid: undefined, supervisorUuid: currentUuid };
-  console.log(`CHAT UUID = ${chatUuid ?? ""}`);
-  console.log(`SUPERVISOR UUID = ${supervisorUuid ?? ""}`);
   const { chats, removeChat } = useChats();
   const { supervisors, removeSupervisor } = useSupervisors();
   const [tab, setTab] = useState<Tab>("chats");
@@ -44,7 +36,6 @@ export function ChatSidebar() {
             uuid={chat.uuid}
             title={chat.prompt}
             removeChat={removeChat}
-            toRedirect={currentUuid === chat.uuid}
           />
         ));
       }

--- a/src/components/conversation.tsx
+++ b/src/components/conversation.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { notFound } from "next/navigation";
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
 
 import { useChats } from "@/hooks/use-chats";
 
@@ -9,12 +10,15 @@ import { Recommendation } from "./recommendation";
 export function Conversation({ uuid }: { uuid: string }) {
   const { getChat, updateChat } = useChats();
   const chat = getChat(uuid);
+  const router = useRouter();
 
-  if (chat === null) {
-    notFound();
-  }
+  useEffect(() => {
+    if (chat === null) {
+      router.replace("/chat");
+    }
+  }, [chat, router]);
 
-  return (
+  return chat === null ? null : (
     <div className="flex flex-col">
       <div className="ml-auto mr-8 flex w-3/4 justify-end md:w-1/2">
         <p className="rounded-2xl bg-chat-user px-4 py-3">{chat.prompt}</p>

--- a/src/components/supervisor-details.tsx
+++ b/src/components/supervisor-details.tsx
@@ -2,7 +2,8 @@
 
 import { ArrowLeft } from "lucide-react";
 import Link from "next/link";
-import { notFound } from "next/navigation";
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
 
 import { useChats } from "@/hooks/use-chats";
 import { useSupervisors } from "@/hooks/use-supervisors";
@@ -23,12 +24,15 @@ function SupervisorDetails({ uuid }: { uuid: string }) {
   const { getChat } = useChats();
   const supervisor = getSupervisor(uuid);
   const chat = getChat(supervisor?.chatUuid ?? "");
+  const router = useRouter();
 
-  if (supervisor === null) {
-    notFound();
-  }
+  useEffect(() => {
+    if (supervisor === null) {
+      router.replace("/chat");
+    }
+  }, [supervisor, router]);
 
-  return (
+  return supervisor === null ? null : (
     <>
       <div className="text-sm">
         {chat === null ? (


### PR DESCRIPTION
## Previous solution
Both `conversation.tsx` and `supervisor-details.tsx` components were throwing a NEXT_NOT_FOUND error through [notFound()](https://nextjs.org/docs/app/api-reference/functions/not-found) function when the chat or supervisor objects were null
## First fix attempt by @chewmanji (038193c3962b35762b9db99356ab8daea270f538)
This attempt, which was also my first thought on how we can solve this problem, consisted of redirecting the user to `/chat` route when clicking on the sidebar delete icon whenever we were deleting the currently active entry. This approach **doesn't work**. Here's my conclusion as to why:
1. The user deletes currently viewed entry through the sidebar
2. `router.replace("/chat")` is fired in the sidebar button onClick callback and is **queued**
3. `removeChat(uuid)` or `removeSupervisor(uuid)` is called, triggering global state change
4. This state change triggers a re-render of either `conversation.tsx` and `supervisor-details.tsx`
5. Due to the chat/supervisor variables now being null, the components throw a 404, **terminating rendering of current route** (as per the next.js docs)
6. Since the route render was terminated, *I assume* that `router.replace("/chat")` was effectively canceled before it could run
## Second fix attempt by me (8e238928900dea94b7ba35846411b92267bafacc)
In my attempt I decided to do all the redirect logic within `conversation.tsx` and `supervisor-details.tsx` as their re-renders are triggered by global state modification. We're no longer calling notFound(), instead we have an useEffect watching chat/supervisor variable changes and then checking if they're null - if so, we redirect to `/chat`. Current "flow" overview:
1. The user deletes currently viewed entry through the sidebar
2. Either `conversation.tsx` or `supervisor-details.tsx` is re-rendered due to global state change
3. This causes chat/supervisor variable to be now null, since the chat with given UUID no longer exists, therefore the view component renders nothing (returns null itself) and `router.replace("/chat")` executes in the useEffect.
### Tested aspects
- [x] Deleting currently viewed chat
- [x] Deleting currently viewed supervisor
- [x] Entering a route with invalid chat UUID
- [x] Entering a route with invalid supervisor UUID