### PR TITLE
Add new chat/supervisor at the beginning of list and timestamps

### DIFF
--- a/src/components/prompt-form.tsx
+++ b/src/components/prompt-form.tsx
@@ -58,6 +58,7 @@ export function PromptForm() {
       uuid,
       prompt,
       faculty: faculty === "any" ? "" : faculty,
+      createdAt: new Date(),
     };
     addChat(chat);
     router.push(`/chat/${uuid}`);

--- a/src/components/supervisor.tsx
+++ b/src/components/supervisor.tsx
@@ -48,6 +48,7 @@ export function Supervisor({
                   papers,
                   prompt,
                   chatUuid,
+                  createdAt: new Date(),
                 });
               }
         }

--- a/src/hooks/use-chats.ts
+++ b/src/hooks/use-chats.ts
@@ -16,7 +16,7 @@ export function useChats() {
 
   const addChat = useCallback(
     (newChat: Chat) => {
-      setChats((previousChats) => [...previousChats, newChat]);
+      setChats((previousChats) => [newChat, ...previousChats]);
     },
     [setChats],
   );

--- a/src/hooks/use-supervisors.ts
+++ b/src/hooks/use-supervisors.ts
@@ -17,8 +17,8 @@ export function useSupervisors() {
   const addSupervisor = useCallback(
     (supervisor: SavedSupervisor) => {
       setSupervisors((previousSupervisors) => [
-        ...previousSupervisors,
         supervisor,
+        ...previousSupervisors,
       ]);
     },
     [setSupervisors],

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -6,4 +6,5 @@ export interface Chat {
   faculty: string;
   helloMessage?: string;
   supervisors?: Supervisor[];
+  createdAt: Date;
 }

--- a/src/types/supervisor.ts
+++ b/src/types/supervisor.ts
@@ -16,6 +16,7 @@ interface Supervisor extends SupervisorResponse {
 interface SavedSupervisor extends Supervisor {
   prompt: string;
   chatUuid: string;
+  createdAt: Date;
 }
 
 export type { Paper, SupervisorResponse, Supervisor, SavedSupervisor };


### PR DESCRIPTION
Decided to add timestamp `createdAt` in `chat` and `supervisor` for future usage - if we decide to make use of it (e.g migrate from local storage to database, add date groups in sidebar), it will be much easier having data already in