### PR TITLE
fix: add proper accordion implementation

### DIFF
--- a/src/components/recommendation.tsx
+++ b/src/components/recommendation.tsx
@@ -10,6 +10,7 @@ import type { Supervisor as ISupervisor } from "@/types/supervisor";
 
 import { PromochatorIcon } from "./chat";
 import { Supervisor } from "./supervisor";
+import { Accordion } from "./ui/accordion";
 
 function useRecommendationQuery(
   chat: Chat,
@@ -105,18 +106,20 @@ export function Recommendation({
               imageHeight={40}
               imageClassName="py-2 px-1"
             />
-            <p className="rounded-2xl bg-message-primary px-4 py-3">
+            <p className="rounded-2xl bg-chat-bot px-4 py-3">
               {chat.helloMessage}
             </p>
           </div>
-          {chat.supervisors?.map((supervisor) => (
-            <Supervisor
-              key={supervisor.uuid}
-              supervisor={supervisor}
-              prompt={chat.prompt}
-              chatUuid={chat.uuid}
-            />
-          ))}
+          <Accordion type="single" collapsible className="space-y-4">
+            {chat.supervisors?.map((supervisor) => (
+              <Supervisor
+                key={supervisor.uuid}
+                supervisor={supervisor}
+                prompt={chat.prompt}
+                chatUuid={chat.uuid}
+              />
+            ))}
+          </Accordion>
         </>
       )}
     </div>

--- a/src/components/supervisor.tsx
+++ b/src/components/supervisor.tsx
@@ -1,16 +1,13 @@
 "use client";
 
 import { Star } from "lucide-react";
-import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import { useSupervisors } from "@/hooks/use-supervisors";
 import { faculties } from "@/lib/faculties";
-import { cn } from "@/lib/utils";
-import type { Supervisor as ISupervisor } from "@/types/supervisor";
+import type { Supervisor as SupervisorType } from "@/types/supervisor";
 
 import {
-  Accordion,
   AccordionContent,
   AccordionItem,
   AccordionTrigger,
@@ -21,16 +18,15 @@ export function Supervisor({
   chatUuid,
   prompt,
 }: {
-  supervisor: ISupervisor;
+  supervisor: SupervisorType;
   chatUuid: string;
   prompt: string;
 }) {
   const { addSupervisor, getSupervisor, removeSupervisor } = useSupervisors();
-  const [open, setOpen] = useState(false);
   const isSaved = getSupervisor(uuid) !== null;
 
   return (
-    <div className="flex w-full flex-row gap-2">
+    <AccordionItem value={uuid} className="group flex w-full flex-row gap-2">
       <Button
         variant="transparent"
         size="icon"
@@ -59,36 +55,22 @@ export function Supervisor({
           size={24}
         />
       </Button>
-      <Accordion
-        type="single"
-        collapsible
-        className={cn(
-          open ? "bg-message-primary" : "border border-message-primary",
-          "w-full rounded-2xl p-4 transition",
-        )}
-      >
-        <AccordionItem value="id" className="space-y-4">
-          <AccordionTrigger
-            className="py-0"
-            onClick={() => {
-              setOpen(!open);
-            }}
-          >
-            <div className="flex flex-col gap-1">
-              <p className="text-xl font-bold">{name}</p>
-              <p>{faculties[faculty] || "Nieznany wydział"}</p>
+      <div className="w-full rounded-2xl border border-chat-bot p-4 transition group-data-[state=open]:bg-chat-bot">
+        <AccordionTrigger className="py-0">
+          <div className="flex flex-col gap-1">
+            <p className="text-xl font-bold">{name}</p>
+            <p>{faculties[faculty] || "Nieznany wydział"}</p>
+          </div>
+        </AccordionTrigger>
+        <AccordionContent className="space-y-6 pb-2 pt-4">
+          {papers.map(({ title, description }) => (
+            <div key={title} className="flex max-w-lg flex-col gap-1">
+              <p className="text-lg font-medium">{title}</p>
+              <p>{description}</p>
             </div>
-          </AccordionTrigger>
-          <AccordionContent className="space-y-6 p-0">
-            {papers.map(({ title, description }) => (
-              <div key={title} className="flex max-w-lg flex-col gap-1">
-                <p className="text-lg font-medium">{title}</p>
-                <p>{description}</p>
-              </div>
-            ))}
-          </AccordionContent>
-        </AccordionItem>
-      </Accordion>
-    </div>
+          ))}
+        </AccordionContent>
+      </div>
+    </AccordionItem>
   );
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -20,7 +20,6 @@ export default {
         "chat-bot": "#1D2150",
         "chat-user": "#34386A",
         "chat-background": "#060C28",
-        "message-primary": "#5D70B8",
         "t-secondary": "#E6E7FF",
         "paper-entry": "#34386A",
         background: "hsl(var(--background))",


### PR DESCRIPTION
### Changes
- Removed `message-primary` color variable and replaced it with `chat-bot`, as it was the first color used for model responses which provides high level of contrast, and yet it was swapped for very bright blue in later designs for some reason. It's also a common convention in conversation UIs that the user's messages are brighter than the messages of other participants.
- Reworked the accordion:
   - The main `<Accordion/>` element is now located in the `Recommendation` component
   - We map over the supervisors inside of it returning `Supervisor` components
   - The `Supervisor` component now returns `<AccordionItem/>` element
   - Highlighting the currently open accordion is now handled through group/peer tailwind classes and html data attributes instead of state. Radix UI components often expose their state with data attributes which we can then use to conditionally style elements. 

### Mistakes in previous implementation
- Using state the way it was implemented before wouldn't work properly in a properly implemented `<Accordion/>` of type `single`, as the `open` state was triggered by clicking on the `<AccordionTrigger/>`. If we were to click on item A, it would get highlighted, but then if we were to click on item B, item A would still be highlighted along with item B despite it collapsing.
- The `<AccordionItem/>` element in `Supervisor` component had a hard-coded value of `"id"`. Each `<AccordionItem/>` in an `<Accordion/>` should have a unique value, as this is how the radix ui accordion figures out which accordion should be expanded/collapse. Making it a hard-coded, identical value across all accordion item causes all items to expand and collapse at once, no matter which one we click.

### New appearance
<img height="600" src="https://github.com/user-attachments/assets/064185b2-daba-4ae7-86a0-6dda1927b5b4"/>