### PR TITLE
fix: homepage layout shift

### DIFF
--- a/src/components/hero-section.tsx
+++ b/src/components/hero-section.tsx
@@ -74,7 +74,7 @@ export function HeroSection() {
                 <p>Specjalistka w dziedzinie UX Design</p>
               </div>
             </div>
-            <Image src={ChatBot} alt="" className="max-w-xs" />
+            <Image src={ChatBot} alt="" width={300} height={300} />
           </div>
         </div>
       </div>

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -14,7 +14,7 @@ export function Navbar() {
   const [showSidebar, setShowSidebar] = useState<boolean>(false);
   return (
     <>
-      <div
+      <header
         className={cn(
           "flex items-center justify-between",
           showSidebar && "no-scroll",
@@ -24,7 +24,8 @@ export function Navbar() {
           src={PromochatorLogo}
           alt="logo Promochatora"
           width={180}
-          height={34}
+          height={32}
+          className="h-8"
         />
         <div className="hidden flex-row gap-12 whitespace-nowrap lg:flex">
           <Link href="#how-it-works">Jak to działa?</Link>
@@ -35,8 +36,8 @@ export function Navbar() {
             src="/assets/logo/solvro_dark.png"
             alt="Solvro Logo"
             width={150}
-            height={150}
-            className="hidden w-40 lg:flex"
+            height={32}
+            className="hidden h-8 lg:block"
           />
         </Link>
         {/* Mobile icon */}
@@ -53,7 +54,7 @@ export function Navbar() {
             <Equal size={36} />
           </Button>
         )}
-      </div>
+      </header>
       {showSidebar ? (
         <div className="items-right absolute right-0 top-0 flex h-full w-full max-w-sm flex-col justify-start gap-12 bg-[#040314E5] p-6 lg:hidden">
           <div className="flex h-min w-full flex-row items-center justify-between gap-6">


### PR DESCRIPTION
## Cause
This was caused by the "KN Solvro" logo image element in the navbar having a set height of 150px, making it to stretch the entire navbar **before** it loaded and made the navbar height adjust accordingly

## Additional changes
- Changed navbar's html element from `div` to `header`
- Added fixed sizes to the chatbot illustration

## Before and after
### Before
![image](https://github.com/user-attachments/assets/8176299a-8b9d-4e21-ba83-b7ca64076bc8)
### After
![image](https://github.com/user-attachments/assets/f7a643d2-0288-48dc-867d-188ba821a558)
