### PR TITLE
Prevent resending request for recommendation

### DIFF
--- a/src/app/api/recommend/route.ts
+++ b/src/app/api/recommend/route.ts
@@ -11,7 +11,7 @@ export async function POST(request: Request) {
   const body = (await request.json()) as RecommendationRequest;
 
   if (process.env.NODE_ENV === "development") {
-    const response = await mockFetch("/api/recommend");
+    const response = await mockFetch("/recommend/invoke");
     return NextResponse.json(await response.json());
   }
 

--- a/src/atoms/last-request.ts
+++ b/src/atoms/last-request.ts
@@ -3,4 +3,8 @@ import { atomWithStorage } from "jotai/utils";
 export const lastRequestTimestampAtom = atomWithStorage<string | null>(
   "lastRequestTimestamp",
   null,
+  undefined,
+  {
+    getOnInit: true,
+  },
 );

--- a/src/components/chat.tsx
+++ b/src/components/chat.tsx
@@ -1,16 +1,17 @@
 import Image from "next/image";
 
+import { ClientOnly } from "./client-only";
 import { PromptForm } from "./prompt-form";
 
 export function Chat() {
   return (
-    <div className="flex w-full flex-col items-center gap-y-8 align-middle text-t-secondary">
+    <ClientOnly className="flex w-full flex-col items-center gap-y-8 align-middle text-t-secondary">
       <PromochatorLogo />
       <div className="flex w-full flex-col items-center gap-y-3">
         <p className="text-lg">Pomóc wybrać Ci promotora?</p>
         <PromptForm />
       </div>
-    </div>
+    </ClientOnly>
   );
 }
 

--- a/src/components/prompt-form.tsx
+++ b/src/components/prompt-form.tsx
@@ -6,13 +6,13 @@ import { EditorProvider } from "@tiptap/react";
 import { StarterKit } from "@tiptap/starter-kit";
 import { ArrowUp, ClockAlert } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { useEffect, useRef, useState } from "react";
+import { useRef } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { v4 } from "uuid";
 import { z } from "zod";
 
 import { useChats } from "@/hooks/use-chats";
-import { useLastRequestTimestamp } from "@/hooks/use-last-request-timestamp";
+import { useLockDuration } from "@/hooks/use-lock-duration";
 import { faculties } from "@/lib/faculties";
 import type { Chat } from "@/types/chat";
 
@@ -43,52 +43,12 @@ const formSchema = z.object({
   faculty: z.string(),
 });
 
-const LOCK_DURATION_SECONDS = Number(
-  process.env.NEXT_PUBLIC_LOCK_DURATION_SECONDS ?? 60,
-);
-
 export function PromptForm() {
   const router = useRouter();
   const { addChat } = useChats();
   const formRef = useRef<null | HTMLFormElement>(null);
 
-  const { getLastRequestTimestamp, setLastRequestTimestamp } =
-    useLastRequestTimestamp();
-  const [lockDuration, setLockDuration] = useState(0);
-
-  useEffect(() => {
-    const timestamp = getLastRequestTimestamp();
-
-    if (timestamp === null) {
-      return;
-    }
-
-    const delta = Math.floor((Date.now() - timestamp.getTime()) / 1000);
-    const newLockDuration = LOCK_DURATION_SECONDS - delta;
-    if (newLockDuration <= 0 || delta > LOCK_DURATION_SECONDS) {
-      setLockDuration(0);
-      return;
-    }
-
-    if (lockDuration === 0) {
-      setLockDuration(newLockDuration);
-      return;
-    }
-
-    const timeout = setTimeout(() => {
-      setLockDuration((previousLockDuration) => {
-        if (previousLockDuration <= 0) {
-          clearTimeout(timeout);
-          return 0;
-        }
-        return previousLockDuration - 1;
-      });
-    }, 1000);
-
-    return () => {
-      clearTimeout(timeout);
-    };
-  }, [lockDuration, getLastRequestTimestamp]);
+  const { lockDuration, isLocked } = useLockDuration();
 
   const {
     handleSubmit,
@@ -110,7 +70,6 @@ export function PromptForm() {
       createdAt: new Date(),
     };
     addChat(chat);
-    setLastRequestTimestamp(new Date());
     router.push(`/chat/${uuid}`);
   };
 
@@ -172,7 +131,7 @@ export function PromptForm() {
           )}
         />
         <div className="flex items-center gap-x-2">
-          {lockDuration !== 0 && (
+          {!!isLocked && (
             <TooltipProvider delayDuration={0}>
               <Tooltip>
                 <TooltipTrigger className="flex w-12 items-center gap-x-1 text-red-500">
@@ -195,7 +154,7 @@ export function PromptForm() {
             className="aspect-square size-8 rounded-full bg-chat-background"
             size="icon"
             type="submit"
-            disabled={isSubmitting || lockDuration !== 0}
+            disabled={isSubmitting || isLocked}
           >
             <ArrowUp size={20}></ArrowUp>
           </Button>

--- a/src/components/prompt-form.tsx
+++ b/src/components/prompt-form.tsx
@@ -131,7 +131,7 @@ export function PromptForm() {
           )}
         />
         <div className="flex items-center gap-x-2">
-          {!!isLocked && (
+          {isLocked ? (
             <TooltipProvider delayDuration={0}>
               <Tooltip>
                 <TooltipTrigger className="flex w-12 items-center gap-x-1 text-red-500">
@@ -148,7 +148,7 @@ export function PromptForm() {
                 </TooltipContent>
               </Tooltip>
             </TooltipProvider>
-          )}
+          ) : null}
           <Button
             variant="transparent"
             className="aspect-square size-8 rounded-full bg-chat-background"

--- a/src/components/recommendation.tsx
+++ b/src/components/recommendation.tsx
@@ -3,6 +3,8 @@ import { CircleX, LoaderPinwheel } from "lucide-react";
 import { useEffect, useState } from "react";
 import { v4 } from "uuid";
 
+import { useLastRequestTimestamp } from "@/hooks/use-last-request-timestamp";
+import { useLockDuration } from "@/hooks/use-lock-duration";
 import type { RecommendationResponse } from "@/types/api-types";
 import type { Chat } from "@/types/chat";
 import type { Supervisor as ISupervisor } from "@/types/supervisor";
@@ -14,17 +16,30 @@ import { Accordion } from "./ui/accordion";
 function useRecommendationQuery(
   chat: Chat,
   updateChat: (uuid: string, _chat: Partial<Chat>) => void,
+  isLocked: boolean,
+  setLastRequestTimestamp: (date: Date) => void,
 ) {
   return useQuery({
-    queryKey: ["recommendation", chat.uuid, chat.prompt, chat.faculty],
+    queryKey: [
+      "recommendation",
+      chat.uuid,
+      chat.prompt,
+      chat.faculty,
+      isLocked,
+    ],
     queryFn: async () => {
+      setLastRequestTimestamp(new Date());
       const response = await fetch("/api/recommend", {
         method: "POST",
         body: JSON.stringify({
           input: { question: chat.prompt, faculty: chat.faculty },
         }),
       });
-
+      if (!response.ok) {
+        throw new Error("Failed to fetch recommendation", {
+          cause: response.status,
+        });
+      }
       const data = (await response.json()) as RecommendationResponse;
       const supervisorsWithUuid = data.output.recommended_supervisors.map(
         (s) => {
@@ -37,7 +52,8 @@ function useRecommendationQuery(
       });
       return data;
     },
-    enabled: chat.helloMessage === undefined,
+    enabled: chat.helloMessage === undefined && !isLocked,
+    refetchOnWindowFocus: false,
     retry: false,
   });
 }
@@ -49,22 +65,30 @@ export function Recommendation({
   chat: Chat;
   updateChat: (uuid: string, _chat: Partial<Chat>) => void;
 }) {
-  const { isLoading, error } = useRecommendationQuery(chat, updateChat);
+  const { lockDuration, isLocked } = useLockDuration();
+  const { setLastRequestTimestamp } = useLastRequestTimestamp();
+
+  const { isLoading, error } = useRecommendationQuery(
+    chat,
+    updateChat,
+    isLocked,
+    setLastRequestTimestamp,
+  );
   const [loadingMessage, setLoadingMessage] =
     useState<string>(getRandomMessage());
 
   useEffect(() => {
-    const intervalDuration =
+    const timeoutDuration =
       (loadingMessage.split(" ").length / (100 / 60)) * 1000; //average reader WPM - 238
-    const interval = setInterval(() => {
+    const timeout = setTimeout(() => {
       setLoadingMessage(getRandomMessage());
-    }, intervalDuration);
+    }, timeoutDuration);
 
     if (!isLoading) {
-      clearInterval(interval);
+      clearTimeout(timeout);
     }
     return () => {
-      clearInterval(interval);
+      clearTimeout(timeout);
     };
   }, [isLoading, loadingMessage]);
 
@@ -108,7 +132,9 @@ export function Recommendation({
               imageClassName="py-2 px-1"
             />
             <p className="rounded-2xl bg-chat-bot px-4 py-3">
-              {chat.helloMessage}
+              {isLocked && chat.helloMessage === undefined
+                ? `Automatyczne pobranie za ${lockDuration.toString()}`
+                : chat.helloMessage}
             </p>
           </div>
           <Accordion type="single" collapsible className="space-y-4">

--- a/src/components/recommendation.tsx
+++ b/src/components/recommendation.tsx
@@ -133,7 +133,7 @@ export function Recommendation({
             />
             <p className="rounded-2xl bg-chat-bot px-4 py-3">
               {isLocked && chat.helloMessage === undefined
-                ? `Automatyczne pobranie za ${lockDuration.toString()}`
+                ? `Pobieranie rekomendacji zostało anulowane. Ponowne pobranie za ${lockDuration.toString()}`
                 : chat.helloMessage}
             </p>
           </div>

--- a/src/hooks/use-last-request-timestamp.ts
+++ b/src/hooks/use-last-request-timestamp.ts
@@ -1,5 +1,5 @@
 import { useAtom } from "jotai";
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 
 import { lastRequestTimestampAtom } from "@/atoms/last-request";
 
@@ -8,7 +8,7 @@ export function useLastRequestTimestamp() {
     lastRequestTimestampAtom,
   );
 
-  const getLastRequestTimestamp = useCallback(() => {
+  const lastRequestTimestamp = useMemo(() => {
     return lastRequestTimestampStorage === null
       ? null
       : new Date(lastRequestTimestampStorage);
@@ -21,5 +21,8 @@ export function useLastRequestTimestamp() {
     [setLastRequestTimestampStorage],
   );
 
-  return { getLastRequestTimestamp, setLastRequestTimestamp };
+  return {
+    lastRequestTimestamp,
+    setLastRequestTimestamp,
+  };
 }

--- a/src/hooks/use-lock-duration.ts
+++ b/src/hooks/use-lock-duration.ts
@@ -1,0 +1,40 @@
+import { useEffect, useState } from "react";
+
+import { useLastRequestTimestamp } from "@/hooks/use-last-request-timestamp";
+
+const LOCK_DURATION_SECONDS = Number(
+  process.env.NEXT_PUBLIC_LOCK_DURATION_SECONDS ?? 60,
+);
+
+export function useLockDuration() {
+  const { lastRequestTimestamp } = useLastRequestTimestamp();
+  const [lockDuration, setLockDuration] = useState(() => {
+    const timestamp = lastRequestTimestamp;
+    if (timestamp === null) {
+      return 0;
+    }
+    const delta = Math.floor((Date.now() - timestamp.getTime()) / 1000);
+    const newLockDuration = LOCK_DURATION_SECONDS - delta;
+    return Math.max(newLockDuration, 0);
+  });
+
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      setLockDuration((previousLockDuration) => {
+        if (previousLockDuration <= 0) {
+          clearTimeout(timeout);
+          return 0;
+        }
+        return previousLockDuration - 1;
+      });
+    }, 1000);
+
+    return () => {
+      clearTimeout(timeout);
+    };
+  }, [lockDuration]);
+
+  const isLocked = lockDuration > 0;
+
+  return { lockDuration, isLocked };
+}

--- a/src/hooks/use-lock-duration.ts
+++ b/src/hooks/use-lock-duration.ts
@@ -35,6 +35,5 @@ export function useLockDuration() {
   }, [lockDuration]);
 
   const isLocked = lockDuration > 0;
-
   return { lockDuration, isLocked };
 }

--- a/src/lib/mock-fetch.ts
+++ b/src/lib/mock-fetch.ts
@@ -6,7 +6,7 @@ interface MockResponse<T> {
 }
 
 const mockResponses: Record<string, MockResponse<unknown>> = {
-  "/api/recommend": {
+  "/recommend/invoke": {
     data: _mockResponse,
     status: 200,
   },
@@ -30,6 +30,6 @@ export async function mockFetch(
       } as Response;
 
       resolve(response);
-    }, 3000);
+    }, 5000);
   });
 }


### PR DESCRIPTION
Resolves #90 

- added useLockDuration hook which returns the lock duration and boolean value `isLocked`
- adjusted the behaviour of global state `lastRequestTimestamp` by setting `getOnInit` to true - [why](https://jotai.org/docs/utilities/storage#parameters)
- locked resending request after refocusing window - it happens when there's an error and user refocuses a page - we'll need to add a button to error UI which will allow user to refetch data - it will be done in #91 
- locked sending request for recommendation if there's a lock and display appropriate UI
![image](https://github.com/user-attachments/assets/709c75a2-330e-4a56-80cc-38427450be0e)
