### PR TITLE
Add dis/-like option for recommendation

### DIFF
--- a/src/components/recommendation.tsx
+++ b/src/components/recommendation.tsx
@@ -43,7 +43,7 @@ function useRecommendationQuery(
       const data = (await response.json()) as RecommendationResponse;
       const supervisorsWithUuid = data.output.recommended_supervisors.map(
         (s) => {
-          return { ...s, uuid: v4(), isAdequate: undefined } as ISupervisor;
+          return { ...s, uuid: v4() } as ISupervisor;
         },
       );
       updateChat(chat.uuid, {

--- a/src/components/recommendation.tsx
+++ b/src/components/recommendation.tsx
@@ -43,7 +43,7 @@ function useRecommendationQuery(
       const data = (await response.json()) as RecommendationResponse;
       const supervisorsWithUuid = data.output.recommended_supervisors.map(
         (s) => {
-          return { ...s, uuid: v4() } as ISupervisor;
+          return { ...s, uuid: v4(), isAdequate: undefined } as ISupervisor;
         },
       );
       updateChat(chat.uuid, {

--- a/src/components/supervisor.tsx
+++ b/src/components/supervisor.tsx
@@ -1,8 +1,15 @@
 "use client";
 
-import { FileText, GraduationCap, Star } from "lucide-react";
+import {
+  FileText,
+  GraduationCap,
+  Star,
+  ThumbsDown,
+  ThumbsUp,
+} from "lucide-react";
 
 import { Button } from "@/components/ui/button";
+import { useChats } from "@/hooks/use-chats";
 import { useSupervisors } from "@/hooks/use-supervisors";
 import { faculties } from "@/lib/faculties";
 import type { Supervisor as SupervisorType } from "@/types/supervisor";
@@ -12,9 +19,15 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from "./ui/accordion";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "./ui/tooltip";
 
 export function Supervisor({
-  supervisor: { uuid, faculty, name, papers, theses },
+  supervisor,
   chatUuid,
   prompt,
 }: {
@@ -22,6 +35,8 @@ export function Supervisor({
   chatUuid: string;
   prompt: string;
 }) {
+  const { uuid, faculty, name, papers, theses, isAdequate } = { ...supervisor };
+  const { updateSupervisor } = useChats();
   const { addSupervisor, getSupervisor, removeSupervisor } = useSupervisors();
   const isSaved = getSupervisor(uuid) !== null;
 
@@ -45,6 +60,7 @@ export function Supervisor({
                   theses,
                   prompt,
                   chatUuid,
+                  isAdequate: true,
                   createdAt: new Date(),
                 });
               }
@@ -88,6 +104,75 @@ export function Supervisor({
               <p>{description}</p>
             </div>
           ))}
+          <div className="flex items-center justify-end pt-4">
+            <TooltipProvider delayDuration={0}>
+              <Tooltip>
+                <TooltipTrigger>
+                  <span className="mr-2 pt-1">
+                    Czy ta rekomendacja była sensowna?
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent className="text-center">
+                  <span>
+                    Odpowiadając na pytanie pomagasz nam dostrajać model,
+                    <br />
+                    co przełoży się na bardziej jakościowe rekomendacje 😉
+                  </span>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+
+            <Button
+              variant="transparent"
+              size="icon"
+              className="hover:bg-chat-user"
+              onClick={() => {
+                const newIsAdequate =
+                  isAdequate === undefined || !isAdequate ? true : undefined;
+
+                updateSupervisor(chatUuid, {
+                  ...supervisor,
+                  isAdequate: newIsAdequate,
+                });
+              }}
+            >
+              <ThumbsUp
+                size={20}
+                className={
+                  isAdequate === undefined
+                    ? "fill-transparent"
+                    : isAdequate
+                      ? "fill-white"
+                      : "fill-transparent"
+                }
+              />
+            </Button>
+            <Button
+              size="icon"
+              variant="transparent"
+              className="hover:bg-chat-user"
+              onClick={() => {
+                const newIsAdequate =
+                  isAdequate === undefined || isAdequate ? false : undefined;
+
+                updateSupervisor(chatUuid, {
+                  ...supervisor,
+                  isAdequate: newIsAdequate,
+                });
+              }}
+            >
+              <ThumbsDown
+                size={20}
+                className={
+                  isAdequate === undefined
+                    ? "fill-transparent"
+                    : isAdequate
+                      ? "fill-transparent"
+                      : "fill-white"
+                }
+              />
+            </Button>
+          </div>
         </AccordionContent>
       </div>
     </AccordionItem>

--- a/src/components/supervisor.tsx
+++ b/src/components/supervisor.tsx
@@ -60,7 +60,6 @@ export function Supervisor({
                   theses,
                   prompt,
                   chatUuid,
-                  isAdequate: true,
                   createdAt: new Date(),
                 });
               }
@@ -121,7 +120,6 @@ export function Supervisor({
                 </TooltipContent>
               </Tooltip>
             </TooltipProvider>
-
             <Button
               variant="transparent"
               size="icon"
@@ -142,7 +140,7 @@ export function Supervisor({
                   isAdequate === undefined
                     ? "fill-transparent"
                     : isAdequate
-                      ? "fill-white"
+                      ? "fill-white/70"
                       : "fill-transparent"
                 }
               />
@@ -168,7 +166,7 @@ export function Supervisor({
                     ? "fill-transparent"
                     : isAdequate
                       ? "fill-transparent"
-                      : "fill-white"
+                      : "fill-white/70"
                 }
               />
             </Button>

--- a/src/hooks/use-chats.ts
+++ b/src/hooks/use-chats.ts
@@ -3,6 +3,7 @@ import { useCallback } from "react";
 
 import { chatsAtom } from "@/atoms/chats";
 import type { Chat } from "@/types/chat";
+import type { Supervisor } from "@/types/supervisor";
 
 export function useChats() {
   const [chats, setChats] = useAtom(chatsAtom);
@@ -41,11 +42,30 @@ export function useChats() {
     [setChats],
   );
 
+  const updateSupervisor = useCallback(
+    (chatUuid: string, updatedSupervisor: Supervisor) => {
+      setChats((previousChats) =>
+        previousChats.map((chat) => {
+          if (chat.uuid === chatUuid && chat.supervisors !== undefined) {
+            const updatedSupervisors: Supervisor[] = chat.supervisors.map(
+              (s) =>
+                s.uuid === updatedSupervisor.uuid ? updatedSupervisor : s,
+            );
+            return { ...chat, supervisors: updatedSupervisors };
+          }
+          return chat;
+        }),
+      );
+    },
+    [setChats],
+  );
+
   return {
     chats,
     getChat,
     addChat,
     removeChat,
     updateChat,
+    updateSupervisor,
   };
 }

--- a/src/types/supervisor.ts
+++ b/src/types/supervisor.ts
@@ -12,6 +12,7 @@ interface SupervisorResponse {
 
 interface Supervisor extends SupervisorResponse {
   uuid: string;
+  isAdequate: boolean | undefined;
 }
 
 interface SavedSupervisor extends Supervisor {

--- a/src/types/supervisor.ts
+++ b/src/types/supervisor.ts
@@ -12,7 +12,7 @@ interface SupervisorResponse {
 
 interface Supervisor extends SupervisorResponse {
   uuid: string;
-  isAdequate: boolean | undefined;
+  isAdequate?: boolean;
 }
 
 interface SavedSupervisor extends Supervisor {


### PR DESCRIPTION
Resolves #95

- added additional property of `Supervisor` interface - `isAdequate`
- if user clicks on dis/-like button next to each recommended supervisor, the `chats` list in local storage is updated by updating the supervisor object
- for now it becomes a little spaghetti code because of the local storage as the source of data but once we'll migrate to database it should the codebase should be clarified